### PR TITLE
Tests: revamp test suites

### DIFF
--- a/wsdf-derive/src/lib.rs
+++ b/wsdf-derive/src/lib.rs
@@ -136,13 +136,13 @@ pub fn version(input: TokenStream) -> TokenStream {
     let version_info = quote! {
         #[no_mangle]
         #[used]
-        static plugin_version: [std::ffi::c_char; #nr_chars] = [#(#ver_str),*];
+        static PLUGIN_VERSION: [std::ffi::c_char; #nr_chars] = [#(#ver_str),*];
         #[no_mangle]
         #[used]
-        static plugin_want_major: std::ffi::c_int = #ws_major_ver;
+        static PLUGIN_WANT_MAJOR: std::ffi::c_int = #ws_major_ver;
         #[no_mangle]
         #[used]
-        static plugin_want_minor: std::ffi::c_int = #ws_minor_ver;
+        static PLUGIN_WANT_MINOR: std::ffi::c_int = #ws_minor_ver;
 
         #[no_mangle]
         pub extern "C" fn plugin_describe() -> u32 {

--- a/wsdf/tests/simple/version.rs
+++ b/wsdf/tests/simple/version.rs
@@ -4,9 +4,9 @@ version!("0.0.1", 4, 4);
 
 fn main() {
     assert_eq!(
-        plugin_version,
+        PLUGIN_VERSION,
         ['0' as i8, '.' as i8, '0' as i8, '.' as i8, '1' as i8, 0_i8]
     );
-    assert_eq!(plugin_want_major, 4_i32);
-    assert_eq!(plugin_want_minor, 4_i32);
+    assert_eq!(PLUGIN_WANT_MAJOR, 4_i32);
+    assert_eq!(PLUGIN_WANT_MINOR, 4_i32);
 }

--- a/wsdf/tests/simple/version2.rs
+++ b/wsdf/tests/simple/version2.rs
@@ -4,9 +4,9 @@ version!("5.10.01", 10, 100);
 
 fn main() {
     assert_eq!(
-        plugin_version,
+        PLUGIN_VERSION,
         ['5' as i8, '.' as i8, '1' as i8, '0' as i8, '.' as i8, '0' as i8, '1' as i8, 0_i8]
     );
-    assert_eq!(plugin_want_major, 10_i32);
-    assert_eq!(plugin_want_minor, 100_i32);
+    assert_eq!(PLUGIN_WANT_MAJOR, 10_i32);
+    assert_eq!(PLUGIN_WANT_MINOR, 100_i32);
 }


### PR DESCRIPTION
1. Upon deprecated v0.1 API, some of the compile tests no longer make sense to keep (breaking changes to api). Also unit testing should verify correct symbols exported. 
2. Research into moving towards and improving compile time errors.
3. Validation using introspection/reflection of macro to be generated? (e.g. validations that certain fields like `len_field` for `Vec<u8>` fields would be a runtime panic/UB in wireshark(?)