### PR TITLE
feat: improve error reporting

### DIFF
--- a/wsdf-derive/Cargo.toml
+++ b/wsdf-derive/Cargo.toml
@@ -18,6 +18,7 @@ quote = "1.0"
 proc-macro2 = "1.0"
 regex = "1.8"
 once_cell = "1.17"
+proc-macro-error2 = "2.0"
 
 [dev-dependencies]
 wsdf = { version = "0.1", path = "../wsdf" }


### PR DESCRIPTION
Goal is to use `proc-macro-error2` to provide:

- All errors at once instead of one-at-a-time
- More contextual help messages
- Notes pointing to documentation
- Better error spans
- reduce panics for certain error handling and provide useful compile errors instead