### PR TITLE
Use c_char instead of i8 to improve compatibility with linux

### DIFF
--- a/wsdf/src/wireshark/dissector.rs
+++ b/wsdf/src/wireshark/dissector.rs
@@ -1,6 +1,6 @@
 use super::{protocol::*, types::*};
 use epan_sys;
-use std::ffi::c_int;
+use std::ffi::{c_char, c_int};
 
 /// A packet dissector implementation.
 ///
@@ -155,11 +155,11 @@ impl PacketInfo {
         Self { ptr }
     }
     // This raw pointer is managed by the block allocator of wmem
-    pub unsafe fn alloc_string(&self, s: &str) -> *const i8 {
+    pub unsafe fn alloc_string(&self, s: &str) -> *const c_char {
         let c_str = std::ffi::CString::new(s).expect("msg");
         unsafe {
             let size = s.len() + 1; // +1 for null terminator
-            let ptr = epan_sys::wmem_alloc((*self.ptr).pool, size) as *mut i8;
+            let ptr = epan_sys::wmem_alloc((*self.ptr).pool, size) as *mut c_char;
             std::ptr::copy_nonoverlapping(c_str.as_ptr(), ptr, size);
             ptr
         }

--- a/wsdf/src/wireshark/plugin.rs
+++ b/wsdf/src/wireshark/plugin.rs
@@ -135,7 +135,7 @@ macro_rules! plugin {
         #[no_mangle]
         #[used]
         #[allow(non_upper_case_globals)]
-        static plugin_version: [std::ffi::c_char; 6] = [48i8, 46i8, 48i8, 46i8, 49i8, 0i8];
+        static plugin_version: [std::ffi::c_char; 6] = [48, 46, 48, 46, 49, 0];
 
         #[no_mangle]
         #[used]

--- a/wsdf/src/wireshark/types.rs
+++ b/wsdf/src/wireshark/types.rs
@@ -1,9 +1,11 @@
-pub fn to_c_str(s: &str) -> *const i8 {
+use std::ffi::c_char;
+
+pub fn to_c_str(s: &str) -> *const c_char {
     // +1 for null terminator
     let size = s.len() + 1;
     let c_str = unsafe {
-        let ptr = epan_sys::wmem_alloc(epan_sys::wmem_epan_scope(), size) as *mut i8;
-        ptr.copy_from(s.as_ptr() as *const i8, s.len());
+        let ptr = epan_sys::wmem_alloc(epan_sys::wmem_epan_scope(), size) as *mut c_char;
+        ptr.copy_from(s.as_ptr() as *const c_char, s.len());
         *ptr.add(s.len()) = 0;
         ptr
     };


### PR DESCRIPTION
Using `c_char` for some types abstracts away differences between platforms which use `i8` (like macOS) and those that use `u8` (like Linux). I found this change was necessary to build this library on Debian. I've also confirmed that it still builds on macOS.

Resolves #1